### PR TITLE
Trigger CI on push update-scala-cli-setup branch

### DIFF
--- a/.github/workflows/scala-cli-update.yml
+++ b/.github/workflows/scala-cli-update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          branch: update-scala-cli
+          branch: update-scala-cli-setup
           commit-message: Update ScalaCLI
           author: GitHub <noreply@github.com>
           delete-branch: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
     - main
+    - update-scala-cli-setup
     tags:
     - "v*"
   pull_request:


### PR DESCRIPTION
Deploy key can only tigger CI `on: push` event, therefore we have to run test also in `update-scala-cli-setup`