### PR TITLE
Trigger workflow test when push to create-pull-request/patch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
     branches:
     - main
     - update-scala-cli-setup
+    - create-pull-request/patch
     tags:
     - "v*"
   pull_request:


### PR DESCRIPTION
GitHub actions `peter-evans/create-pull-request` uses `Deploy Keys` only to push commit to branch, therefore  this method will only trigger `on: push` workflows - [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs) is an explanation method with SSH keys. 

So I added `create-pull-request/patch` to trigger `test` workflow when `peter-evans/create-pull-request` push commit. 

Method with [SSH (deploy keys)](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys) doesn't work with trigger `on: pull_request`.