### PR TITLE
Fix the CI to actually use node `lts/gallium`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Build
       shell: bash -l {0}
       run: |
+        nvm install lts/gallium
         nvm use lts/gallium
         npm install
         npm run all

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Build
         shell: bash -l {0}
         run: |
+          nvm install lts/gallium
           nvm use lts/gallium
           npm install
           npm run all


### PR DESCRIPTION
Our CI's test build currently logs:
```
Run nvm use lts/gallium
N/A: version "lts/gallium" is not yet installed.

You need to run `nvm install lts/gallium` to install and use it.
```
This ought to fix it.