### PR TITLE
Deprecate Java 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        jvm: ['11', 'temurin:17']
+        jvm: ['temurin:17']
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Java 11 is no longer supported as the runtime for Bloop working with Scala CLI.
Extra context: https://github.com/VirtusLab/scala-cli/pull/2445