### PR TITLE
Enable `COURSIER_BIN_DIR` override & run tests on M1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, macOS-m1, windows-latest]
         jvm: ['temurin:17']
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
     - run: echo 'name := "foo"' > build.sbt
     - id: scala-cli-setup
       uses: ./
+      env:
+        COURSIER_BIN_DIR: ${{ github.workspace }}/cs/bin
       with:
         jvm: ${{ matrix.jvm }}
         apps: sbt sbtn ammonite bloop:1.4.11

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ A GitHub Action to install Scala CLI.
         option, like publishing.
     - Defaults to `false`
 
+### Environment variables
+- `JAVA_HOME`: path to the JVM to use
+- `COURSIER_BIN_DIR`: (optional) path to the directory where Coursier will install app binaries
+   - defaults to `$HOME/cs/bin`
+   - shouldn't have to be tampered with for vanilla GitHub action runners
+   - make sure the directory is reachable for self-hosted runners
+   - in case of issues, you can set it to something like 
+     ```yaml
+     env:
+       COURSIER_BIN_DIR: ${{ github.workspace }}/cs/bin
+     ```
+
 ### Example with custom inputs
 
 ```yml

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,9 +139,17 @@ async function run(): Promise<void> {
       }
       apps.push(`scala-cli${version ? `:${version}` : ''}`)
       if (value && apps.length) {
-        const coursierBinDir = path.join(os.homedir(), 'cs', 'bin')
-        core.exportVariable('COURSIER_BIN_DIR', coursierBinDir)
-        core.addPath(coursierBinDir)
+        if (process.env.COURSIER_BIN_DIR) {
+          core.info(
+            `Using the cs bin directory from COURSIER_BIN_DIR: ${process.env.COURSIER_BIN_DIR}`,
+          )
+          core.addPath(process.env.COURSIER_BIN_DIR)
+        } else {
+          const coursierBinDir = path.join(os.homedir(), 'cs', 'bin')
+          core.info(`Setting COURSIER_BIN_DIR to: ${coursierBinDir}`)
+          core.exportVariable('COURSIER_BIN_DIR', coursierBinDir)
+          core.addPath(coursierBinDir)
+        }
         await cs('install', '--contrib', ...apps)
         core.setOutput(
           'scala-cli-version',


### PR DESCRIPTION
- tests will now also be run on `macOS-m1`
- it is now advised to set `COURSIER_BIN_DIR`to `${{ github.workspace }}/cs/bin` for self-hosted runners (like our M1)