### PR TITLE
Update action to use node 20

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,13 @@
 {
-  "plugins": [
-    "@typescript-eslint"
-  ],
+  "plugins": ["@typescript-eslint"],
   "extends": [
-    "plugin:github/recommended"
+    "plugin:github/typescript"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 9,
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": true
   },
   "rules": {
     "eslint-comments/no-use": "off",
@@ -34,10 +32,7 @@
         "allowExpressions": true
       }
     ],
-    "@typescript-eslint/func-call-spacing": [
-      "error",
-      "never"
-    ],
+    "@typescript-eslint/func-call-spacing": ["error", "never"],
     "@typescript-eslint/no-array-constructor": "error",
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-explicit-any": "warn",
@@ -59,10 +54,7 @@
     "@typescript-eslint/require-array-sort-compare": "error",
     "@typescript-eslint/restrict-plus-operands": "error",
     "semi": "off",
-    "@typescript-eslint/semi": [
-      "error",
-      "never"
-    ],
+    "@typescript-eslint/semi": ["error", "never"],
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/unbound-method": "error",
     "i18n-text/no-en": "off"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '20'
+        cache: 'npm'
     - name: Build
       shell: bash -l {0}
       run: |
-        nvm install lts/gallium
-        nvm use lts/gallium
-        npm install
+        npm ci
         npm run all
 
     # create an sbt file to enabling sbt caching

--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -11,12 +11,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SCALA_CLI_SETUP_INTERNAL_KEY }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+          cache: 'npm'
       - name: Build
         shell: bash -l {0}
         run: |
-          nvm install lts/gallium
-          nvm use lts/gallium
-          npm install
+          npm ci
           npm run all
 
       - name: Create Pull Request

--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ outputs:
   scala-cli-version:
     description: 'Version of the installed Scala CLI'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.17",
-        "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^6.21.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.1",
+        "@typescript-eslint/parser": "^7.0.1",
         "@vercel/ncc": "^0.38.1",
         "eslint": "^8.56.0",
         "eslint-plugin-github": "^4.10.1",
@@ -284,16 +284,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.0.tgz",
-      "integrity": "sha512-M72SJ0DkcQVmmsbqlzc6EJgb/3Oz2Wdm6AyESB4YkGgCxP8u5jt5jn4/OBMPK3HLOxcttZq5xbBBU7e2By4SZQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.1.tgz",
+      "integrity": "sha512-OLvgeBv3vXlnnJGIAgCLYKjgMEU+wBGj07MQ/nxAaON+3mLzX7mJbhRYrVGiVvFiXtwFlkcBa/TtmglHy0UbzQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.0.0",
-        "@typescript-eslint/type-utils": "7.0.0",
-        "@typescript-eslint/utils": "7.0.0",
-        "@typescript-eslint/visitor-keys": "7.0.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/type-utils": "7.0.1",
+        "@typescript-eslint/utils": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -309,7 +309,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "@typescript-eslint/parser": "^7.0.0",
         "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
@@ -319,13 +319,13 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.0.tgz",
-      "integrity": "sha512-IxTStwhNDPO07CCrYuAqjuJ3Xf5MrMaNgbAZPxFXAUpAtwqFxiuItxUaVtP/SJQeCdJjwDGh9/lMOluAndkKeg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+      "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.0",
-        "@typescript-eslint/visitor-keys": "7.0.0"
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -336,9 +336,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-9ZIJDqagK1TTs4W9IyeB2sH/s1fFhN9958ycW8NRTg1vXGzzH5PQNzq6KbsbVGMT+oyyfa17DfchHDidcmf5cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+      "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -349,12 +349,12 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.0.tgz",
-      "integrity": "sha512-JZP0uw59PRHp7sHQl3aF/lFgwOW2rgNVnXUksj1d932PMita9wFBd3621vHQRDvHwPsSY9FMAAHVc8gTvLYY4w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+      "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.0",
+        "@typescript-eslint/types": "7.0.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -366,15 +366,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.1.tgz",
+      "integrity": "sha512-8GcRRZNzaHxKzBPU3tKtFNing571/GwPBeCvmAUw0yBtfE2XVd0zFKJIMSWkHJcPQi0ekxjIts6L/rrZq5cxGQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/typescript-estree": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -385,12 +385,111 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+      "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+      "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+      "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+      "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.0.1",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -411,13 +510,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.0.tgz",
-      "integrity": "sha512-FIM8HPxj1P2G7qfrpiXvbHeHypgo2mFpFGoh5I73ZlqmJOsloSa1x0ZyXCer43++P1doxCgNqIOLqmZR6SOT8g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.1.tgz",
+      "integrity": "sha512-YtT9UcstTG5Yqy4xtLiClm1ZpM/pWVGFnkAa90UfdkkZsR1eP2mR/1jbHeYp8Ay1l1JHPyGvoUYR6o3On5Nhmw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.0.0",
-        "@typescript-eslint/utils": "7.0.0",
+        "@typescript-eslint/typescript-estree": "7.0.1",
+        "@typescript-eslint/utils": "7.0.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -438,9 +537,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-9ZIJDqagK1TTs4W9IyeB2sH/s1fFhN9958ycW8NRTg1vXGzzH5PQNzq6KbsbVGMT+oyyfa17DfchHDidcmf5cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+      "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -451,13 +550,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.0.tgz",
-      "integrity": "sha512-JzsOzhJJm74aQ3c9um/aDryHgSHfaX8SHFIu9x4Gpik/+qxLvxUylhTsO9abcNu39JIdhY2LgYrFxTii3IajLA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+      "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.0",
-        "@typescript-eslint/visitor-keys": "7.0.0",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -479,12 +578,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.0.tgz",
-      "integrity": "sha512-JZP0uw59PRHp7sHQl3aF/lFgwOW2rgNVnXUksj1d932PMita9wFBd3621vHQRDvHwPsSY9FMAAHVc8gTvLYY4w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+      "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.0",
+        "@typescript-eslint/types": "7.0.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -585,17 +684,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.0.tgz",
-      "integrity": "sha512-kuPZcPAdGcDBAyqDn/JVeJVhySvpkxzfXjJq1X1BFSTYo1TTuo4iyb937u457q4K0In84p6u2VHQGaFnv7VYqg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-oe4his30JgPbnv+9Vef1h48jm0S6ft4mNwi9wj7bX10joGn07QRfqIqFHoMiajrtoU88cIhXf8ahwgrcbNLgPA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.0.0",
-        "@typescript-eslint/types": "7.0.0",
-        "@typescript-eslint/typescript-estree": "7.0.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/typescript-estree": "7.0.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -610,13 +709,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.0.tgz",
-      "integrity": "sha512-IxTStwhNDPO07CCrYuAqjuJ3Xf5MrMaNgbAZPxFXAUpAtwqFxiuItxUaVtP/SJQeCdJjwDGh9/lMOluAndkKeg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+      "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.0",
-        "@typescript-eslint/visitor-keys": "7.0.0"
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -627,9 +726,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-9ZIJDqagK1TTs4W9IyeB2sH/s1fFhN9958ycW8NRTg1vXGzzH5PQNzq6KbsbVGMT+oyyfa17DfchHDidcmf5cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+      "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -640,13 +739,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.0.tgz",
-      "integrity": "sha512-JzsOzhJJm74aQ3c9um/aDryHgSHfaX8SHFIu9x4Gpik/+qxLvxUylhTsO9abcNu39JIdhY2LgYrFxTii3IajLA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+      "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.0",
-        "@typescript-eslint/visitor-keys": "7.0.0",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -668,12 +767,12 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.0.tgz",
-      "integrity": "sha512-JZP0uw59PRHp7sHQl3aF/lFgwOW2rgNVnXUksj1d932PMita9wFBd3621vHQRDvHwPsSY9FMAAHVc8gTvLYY4w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+      "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.0.0",
+        "@typescript-eslint/types": "7.0.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1608,6 +1707,34 @@
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -4267,16 +4394,16 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.0.tgz",
-      "integrity": "sha512-M72SJ0DkcQVmmsbqlzc6EJgb/3Oz2Wdm6AyESB4YkGgCxP8u5jt5jn4/OBMPK3HLOxcttZq5xbBBU7e2By4SZQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.1.tgz",
+      "integrity": "sha512-OLvgeBv3vXlnnJGIAgCLYKjgMEU+wBGj07MQ/nxAaON+3mLzX7mJbhRYrVGiVvFiXtwFlkcBa/TtmglHy0UbzQ==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "7.0.0",
-        "@typescript-eslint/type-utils": "7.0.0",
-        "@typescript-eslint/utils": "7.0.0",
-        "@typescript-eslint/visitor-keys": "7.0.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/type-utils": "7.0.1",
+        "@typescript-eslint/utils": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -4286,44 +4413,106 @@
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.0.tgz",
-          "integrity": "sha512-IxTStwhNDPO07CCrYuAqjuJ3Xf5MrMaNgbAZPxFXAUpAtwqFxiuItxUaVtP/SJQeCdJjwDGh9/lMOluAndkKeg==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+          "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "7.0.0",
-            "@typescript-eslint/visitor-keys": "7.0.0"
+            "@typescript-eslint/types": "7.0.1",
+            "@typescript-eslint/visitor-keys": "7.0.1"
           }
         },
         "@typescript-eslint/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-9ZIJDqagK1TTs4W9IyeB2sH/s1fFhN9958ycW8NRTg1vXGzzH5PQNzq6KbsbVGMT+oyyfa17DfchHDidcmf5cg==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+          "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
           "dev": true
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.0.tgz",
-          "integrity": "sha512-JZP0uw59PRHp7sHQl3aF/lFgwOW2rgNVnXUksj1d932PMita9wFBd3621vHQRDvHwPsSY9FMAAHVc8gTvLYY4w==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+          "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "7.0.0",
+            "@typescript-eslint/types": "7.0.1",
             "eslint-visitor-keys": "^3.4.1"
           }
         }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.1.tgz",
+      "integrity": "sha512-8GcRRZNzaHxKzBPU3tKtFNing571/GwPBeCvmAUw0yBtfE2XVd0zFKJIMSWkHJcPQi0ekxjIts6L/rrZq5cxGQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/typescript-estree": "7.0.1",
+        "@typescript-eslint/visitor-keys": "7.0.1",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+          "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "7.0.1",
+            "@typescript-eslint/visitor-keys": "7.0.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+          "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+          "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "7.0.1",
+            "@typescript-eslint/visitor-keys": "7.0.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "minimatch": "9.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+          "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "7.0.1",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
@@ -4337,31 +4526,31 @@
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.0.tgz",
-      "integrity": "sha512-FIM8HPxj1P2G7qfrpiXvbHeHypgo2mFpFGoh5I73ZlqmJOsloSa1x0ZyXCer43++P1doxCgNqIOLqmZR6SOT8g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.1.tgz",
+      "integrity": "sha512-YtT9UcstTG5Yqy4xtLiClm1ZpM/pWVGFnkAa90UfdkkZsR1eP2mR/1jbHeYp8Ay1l1JHPyGvoUYR6o3On5Nhmw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "7.0.0",
-        "@typescript-eslint/utils": "7.0.0",
+        "@typescript-eslint/typescript-estree": "7.0.1",
+        "@typescript-eslint/utils": "7.0.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
       "dependencies": {
         "@typescript-eslint/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-9ZIJDqagK1TTs4W9IyeB2sH/s1fFhN9958ycW8NRTg1vXGzzH5PQNzq6KbsbVGMT+oyyfa17DfchHDidcmf5cg==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+          "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.0.tgz",
-          "integrity": "sha512-JzsOzhJJm74aQ3c9um/aDryHgSHfaX8SHFIu9x4Gpik/+qxLvxUylhTsO9abcNu39JIdhY2LgYrFxTii3IajLA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+          "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "7.0.0",
-            "@typescript-eslint/visitor-keys": "7.0.0",
+            "@typescript-eslint/types": "7.0.1",
+            "@typescript-eslint/visitor-keys": "7.0.1",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -4371,12 +4560,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.0.tgz",
-          "integrity": "sha512-JZP0uw59PRHp7sHQl3aF/lFgwOW2rgNVnXUksj1d932PMita9wFBd3621vHQRDvHwPsSY9FMAAHVc8gTvLYY4w==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+          "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "7.0.0",
+            "@typescript-eslint/types": "7.0.1",
             "eslint-visitor-keys": "^3.4.1"
           }
         },
@@ -4443,44 +4632,44 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.0.tgz",
-      "integrity": "sha512-kuPZcPAdGcDBAyqDn/JVeJVhySvpkxzfXjJq1X1BFSTYo1TTuo4iyb937u457q4K0In84p6u2VHQGaFnv7VYqg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.1.tgz",
+      "integrity": "sha512-oe4his30JgPbnv+9Vef1h48jm0S6ft4mNwi9wj7bX10joGn07QRfqIqFHoMiajrtoU88cIhXf8ahwgrcbNLgPA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "7.0.0",
-        "@typescript-eslint/types": "7.0.0",
-        "@typescript-eslint/typescript-estree": "7.0.0",
+        "@typescript-eslint/scope-manager": "7.0.1",
+        "@typescript-eslint/types": "7.0.1",
+        "@typescript-eslint/typescript-estree": "7.0.1",
         "semver": "^7.5.4"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.0.tgz",
-          "integrity": "sha512-IxTStwhNDPO07CCrYuAqjuJ3Xf5MrMaNgbAZPxFXAUpAtwqFxiuItxUaVtP/SJQeCdJjwDGh9/lMOluAndkKeg==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.1.tgz",
+          "integrity": "sha512-v7/T7As10g3bcWOOPAcbnMDuvctHzCFYCG/8R4bK4iYzdFqsZTbXGln0cZNVcwQcwewsYU2BJLay8j0/4zOk4w==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "7.0.0",
-            "@typescript-eslint/visitor-keys": "7.0.0"
+            "@typescript-eslint/types": "7.0.1",
+            "@typescript-eslint/visitor-keys": "7.0.1"
           }
         },
         "@typescript-eslint/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-9ZIJDqagK1TTs4W9IyeB2sH/s1fFhN9958ycW8NRTg1vXGzzH5PQNzq6KbsbVGMT+oyyfa17DfchHDidcmf5cg==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.1.tgz",
+          "integrity": "sha512-uJDfmirz4FHib6ENju/7cz9SdMSkeVvJDK3VcMFvf/hAShg8C74FW+06MaQPODHfDJp/z/zHfgawIJRjlu0RLg==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.0.tgz",
-          "integrity": "sha512-JzsOzhJJm74aQ3c9um/aDryHgSHfaX8SHFIu9x4Gpik/+qxLvxUylhTsO9abcNu39JIdhY2LgYrFxTii3IajLA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.1.tgz",
+          "integrity": "sha512-SO9wHb6ph0/FN5OJxH4MiPscGah5wjOd0RRpaLvuBv9g8565Fgu0uMySFEPqwPHiQU90yzJ2FjRYKGrAhS1xig==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "7.0.0",
-            "@typescript-eslint/visitor-keys": "7.0.0",
+            "@typescript-eslint/types": "7.0.1",
+            "@typescript-eslint/visitor-keys": "7.0.1",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -4490,12 +4679,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.0.tgz",
-          "integrity": "sha512-JZP0uw59PRHp7sHQl3aF/lFgwOW2rgNVnXUksj1d932PMita9wFBd3621vHQRDvHwPsSY9FMAAHVc8gTvLYY4w==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.1.tgz",
+          "integrity": "sha512-hwAgrOyk++RTXrP4KzCg7zB2U0xt7RUU0ZdMSCsqF3eKUwkdXUMyTb0qdCuji7VIbcpG62kKTU9M1J1c9UpFBw==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "7.0.0",
+            "@typescript-eslint/types": "7.0.1",
             "eslint-visitor-keys": "^3.4.1"
           }
         },
@@ -5261,6 +5450,19 @@
             "natural-compare": "^1.4.0",
             "semver": "^7.5.4",
             "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+          "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/scope-manager": "6.21.0",
+            "@typescript-eslint/types": "6.21.0",
+            "@typescript-eslint/typescript-estree": "6.21.0",
+            "@typescript-eslint/visitor-keys": "6.21.0",
+            "debug": "^4.3.4"
           }
         },
         "@typescript-eslint/type-utils": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
-    "@typescript-eslint/parser": "^6.21.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.1",
+    "@typescript-eslint/parser": "^7.0.1",
     "@vercel/ncc": "^0.38.1",
     "eslint": "^8.56.0",
     "eslint-plugin-github": "^4.10.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -170,4 +170,4 @@ async function run(): Promise<void> {
   }
 }
 
-run()
+void run()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es2022",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "outDir": "./lib",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
Actions will deprecate node 20 soon: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

Also updates CI node versions and [tsconfig target](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)
