### PR TITLE
Bump `coursier` to 2.1.14

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ const architecture_aarch64 = 'aarch64'
 
 const architecture = getArchitecture()
 
-const csDefaultVersion_x86_64 = '2.1.13'
-const csDefaultVersion_aarch64 = '2.1.13'
+const csDefaultVersion_x86_64 = '2.1.14'
+const csDefaultVersion_aarch64 = '2.1.14'
 
 const csVersion =
   core.getInput('version') ||


### PR DESCRIPTION
- https://github.com/VirtusLab/coursier-m1/releases/tag/v2.1.14
- https://github.com/coursier/coursier/releases/tag/v2.1.14