### PR TITLE
Bump `scala-cli` to 1.5.3

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import * as os from 'os'
 import * as path from 'path'
 import * as tc from '@actions/tool-cache'
 
-const scalaCLIVersion = '1.5.1'
+const scalaCLIVersion = '1.5.3'
 
 const architecture_x86_64 = 'x86_64'
 const architecture_aarch64 = 'aarch64'


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.5.3
This PR would normally be created automatically. Doing it by hand after the recent CI failure.
https://github.com/VirtusLab/scala-cli/issues/3273#issuecomment-2476641331