### PR TITLE
Bump `coursier` to 2.1.24

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ const architecture_aarch64 = 'aarch64'
 
 const architecture = getArchitecture()
 
-const csDefaultVersion_x86_64 = '2.1.22'
-const csDefaultVersion_aarch64 = '2.1.22'
+const csDefaultVersion_x86_64 = '2.1.24'
+const csDefaultVersion_aarch64 = '2.1.24'
 
 const csVersion =
   core.getInput('version') ||


### PR DESCRIPTION
- https://github.com/coursier/coursier/releases/tag/v2.1.24
- https://github.com/VirtusLab/coursier-m1/releases/tag/v2.1.24