### PR TITLE
Bump Scala CLI to v1.6.0

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import * as os from 'os'
 import * as path from 'path'
 import * as tc from '@actions/tool-cache'
 
-const scalaCLIVersion = '1.5.4'
+const scalaCLIVersion = '1.6.0'
 
 const architecture_x86_64 = 'x86_64'
 const architecture_aarch64 = 'aarch64'


### PR DESCRIPTION
As our CI broke while releasing Scala CLI v1.6.0, the version wasn't bumped automatically.
It should be fine to still use it on the GH action.