### PR TITLE
Bump Node to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ outputs:
   scala-cli-version:
     description: 'Version of the installed Scala CLI'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/