### PR TITLE
Bump `coursier` to 2.1.25-M26 (was 2.1.25-M25)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ const architecture_aarch64 = 'aarch64'
 
 const architecture = getArchitecture()
 
-const csDefaultVersion = '2.1.25-M25'
+const csDefaultVersion = '2.1.25-M26'
 const csVersion = core.getInput('version') || csDefaultVersion
 
 const coursierVersionSpec = csVersion


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M26